### PR TITLE
PokéCenter changes

### DIFF
--- a/files/msgdata/msg/msg_0040.gmm
+++ b/files/msgdata/msg/msg_0040.gmm
@@ -2,15 +2,15 @@
 <body language="English">
 	<row id="msg_0040_00000" index="0">
 		<attribute name="window_context_name">used</attribute>
-		<language name="English">Hello, and welcome to\nthe Pokémon Center.\rWe restore your tired Pokémon\nto full health.\rWould you like to rest your\nPokémon?{YESNO 0}</language>
+		<language name="English">Hello, and welcome to\nthe PokéCenter.\rWould you like to rest your\nPokémon?{YESNO 0}</language>
 	</row>
 	<row id="msg_0040_00001" index="1">
 		<attribute name="window_context_name">used</attribute>
-		<language name="English">OK, I’ll take your Pokémon for a few\nseconds.</language>
+		<language name="English">OK, I’ll take your Pokémon for a few\nseconds...</language>
 	</row>
 	<row id="msg_0040_00002" index="2">
 		<attribute name="window_context_name">used</attribute>
-		<language name="English">Thank you for waiting.\rWe’ve restored your Pokémon to full\nhealth.\r</language>
+		<language name="English">Your Pokémon are at full health.\r</language>
 	</row>
 	<row id="msg_0040_00003" index="3">
 		<attribute name="window_context_name">used</attribute>
@@ -18,7 +18,7 @@
 	</row>
 	<row id="msg_0040_00004" index="4">
 		<attribute name="window_context_name">used</attribute>
-		<language name="English">Hello, and welcome to\nthe Pokémon Center.\rWe restore your tired Pokémon\nto full health.\rWould you like to...\r</language>
+		<language name="English">Hello, and welcome to\nthe PokéCenter.\rWe restore your tired Pokémon\nto full health.\rWould you like to...\r</language>
 	</row>
 	<row id="msg_0040_00005" index="5">
 		<attribute name="window_context_name">used</attribute>
@@ -178,7 +178,7 @@
 	</row>
 	<row id="msg_0040_00042" index="42">
 		<attribute name="window_context_name">used</attribute>
-		<language name="English">Mom: Oh, good! You and your\nPokémon are looking great.\rOh, yes, I heard from Professor Elm.\rHe said that a Pokémon’s energy is\nmeasured in HP (Hit Points).\rIf your Pokémon lose their HP,\nyou can restore it at any\fPokémon Center.\rIf you’re going to travel far away,\nthe smart Trainer stocks up on\fPotions at the Pokémon Mart.\rMake me proud, honey!\nTake care!</language>
+		<language name="English">Mom: Oh, good! You and your\nPokémon are looking great.\rOh, yes, I heard from Professor Elm.\rHe said that a Pokémon’s energy is\nmeasured in HP (Hit Points).\rIf your Pokémon lose their HP,\nyou can restore it at any\fPokéCenter.\rIf you’re going to travel far away,\nthe smart Trainer stocks up on\fPotions at the Pokémon Mart.\rMake me proud, honey!\nTake care!</language>
 	</row>
 	<row id="msg_0040_00043" index="43">
 		<attribute name="window_context_name">used</attribute>
@@ -194,7 +194,7 @@
 	</row>
 	<row id="msg_0040_00046" index="46">
 		<attribute name="window_context_name">used</attribute>
-		<language name="English">Please visit a Pokémon Center when\nyour Pokémon’s HP goes down.\rIf you’re planning to travel any\ndistance, you should stock up on\fPotions at a Pokémon Mart.\rGood luck, Trainer!</language>
+		<language name="English">Please visit a PokéCenter when\nyour Pokémon’s HP goes down.\rIf you’re planning to travel any\ndistance, you should stock up on\fPotions at a Pokémon Mart.\rGood luck, Trainer!</language>
 	</row>
 	<row id="msg_0040_00047" index="47">
 		<attribute name="window_context_name">used</attribute>
@@ -349,11 +349,11 @@
 	</row>
 	<row id="msg_0040_00083" index="83">
 		<attribute name="window_context_name">used</attribute>
-		<language name="English">Good morning!\nWelcome to the Pokémon Center.\rWould you like to rest your\nPokémon? {YESNO 0}</language>
+		<language name="English">Good morning!\nWelcome to the PokéCenter.\rWould you like to rest your\nPokémon? {YESNO 0}</language>
 	</row>
 	<row id="msg_0040_00084" index="84">
 		<attribute name="window_context_name">used</attribute>
-		<language name="English">Welcome to the Pokémon Center.\rWould you like to rest your\nPokémon? {YESNO 0}</language>
+		<language name="English">Welcome to the PokéCenter.\rWould you like to rest your\nPokémon? {YESNO 0}</language>
 	</row>
 	<row id="msg_0040_00085" index="85">
 		<attribute name="window_context_name">used</attribute>

--- a/files/msgdata/msg/msg_0412.gmm
+++ b/files/msgdata/msg/msg_0412.gmm
@@ -11,7 +11,7 @@
 	</row>
 	<row id="msg_0412_00002" index="2">
 		<attribute name="window_context_name">used</attribute>
-		<language name="English">Commercial: Always where you need it!\nYour local Pokémon Center!</language>
+		<language name="English">Commercial: Always where you need it!\nYour local PokéCenter!</language>
 	</row>
 	<row id="msg_0412_00003" index="3">
 		<attribute name="window_context_name">used</attribute>
@@ -55,11 +55,11 @@
 	</row>
 	<row id="msg_0412_00013" index="13">
 		<attribute name="window_context_name">used</attribute>
-		<language name="English">Commercial: A fateful encounter that\nbegins in the Pokémon Center...\nA connection between two people...\nIf you climb the stairs, you’ll find it.\nThe Union Room.</language>
+		<language name="English">Commercial: A fateful encounter that\nbegins in the PokéCenter...\nA connection between two people...\nIf you climb the stairs, you’ll find it.\nThe Union Room.</language>
 	</row>
 	<row id="msg_0412_00014" index="14">
 		<attribute name="window_context_name">used</attribute>
-		<language name="English">Commercial: A fateful encounter that\nbegins in the Pokémon Center...\nA connection between two people...\nIf you take the escalator down, you’ll\nfind it--the Wi-Fi Club.</language>
+		<language name="English">Commercial: A fateful encounter that\nbegins in the PokéCenter...\nA connection between two people...\nIf you take the escalator down, you’ll\nfind it--the Wi-Fi Club.</language>
 	</row>
 	<row id="msg_0412_00015" index="15">
 		<attribute name="window_context_name">used</attribute>

--- a/files/msgdata/msg/msg_0415.gmm
+++ b/files/msgdata/msg/msg_0415.gmm
@@ -26,7 +26,7 @@
 	</row>
 	<row id="msg_0415_00006" index="6">
 		<attribute name="window_context_name">used</attribute>
-		<language name="English">Announcing the top 3 in Violet City!\nNumber three is... Ta-da!\nThe arched bridge!\nThis bridge extends over the river\nrunning through the town, and is so\nround it reminds the residents of a drum.\nMoving on, number two is... Ta-da!\nThe stylish Pokémon Center!\nThis Pokémon Center is painted in natural\ncolors so as to blend in with the\nbeautiful scenery around it, rather than\nstanding out. Very stylish!\nAnd the number one thing is... Ta-da!\nSprout Tower!\nSprout Tower is always slowly swaying\nback and forth, and it’s the place where\nTrainers practice if they’re aiming for\nthe top! It’s strict, which is why it’s\npopular, and that’s why it’s our splendid\nnumber one!</language>
+		<language name="English">Announcing the top 3 in Violet City!\nNumber three is... Ta-da!\nThe arched bridge!\nThis bridge extends over the river\nrunning through the town, and is so\nround it reminds the residents of a drum.\nMoving on, number two is... Ta-da!\nThe stylish PokéCenter!\nThis PokéCenter is painted in natural\ncolors so as to blend in with the\nbeautiful scenery around it, rather than\nstanding out. Very stylish!\nAnd the number one thing is... Ta-da!\nSprout Tower!\nSprout Tower is always slowly swaying\nback and forth, and it’s the place where\nTrainers practice if they’re aiming for\nthe top! It’s strict, which is why it’s\npopular, and that’s why it’s our splendid\nnumber one!</language>
 	</row>
 	<row id="msg_0415_00007" index="7">
 		<attribute name="window_context_name">used</attribute>


### PR DESCRIPTION
Updating every mention of Pokémon Center to "PokéCenter" to reduce the amount of text by a small amount and add a bit of stylistic flair.
Trying to make grinding a little easier too, by reducing the length of repetitive dialogue.